### PR TITLE
cd failing: version bump webfactory/ssh-agent to 0.9.0

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,7 +39,7 @@ jobs:
           key: ${{ secrets.TRELLIS_DEPLOY_SSH_PRIVATE_KEY }}
           known_hosts: ${{ secrets.TRELLIS_DEPLOY_SSH_KNOWN_HOSTS }}
 
-      - uses: webfactory/ssh-agent@v0.8.0
+      - uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.TRELLIS_DEPLOY_SSH_PRIVATE_KEY }}
 


### PR DESCRIPTION
Based on note at bottom of failed cd workflow:

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: webfactory/ssh-agent@v0.8.0, roots/setup-trellis-cli@v1. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.```

However: `roots/setup-trellis-cli` is at latest, so dubious.  And the reported build failure suggests something is still at node 16, which is now EOL.