### PR TITLE
revert roots/bug 6.21.0 to 6.20.0

### DIFF
--- a/web/app/themes/asmm/package.json
+++ b/web/app/themes/asmm/package.json
@@ -22,7 +22,7 @@
     "translate:mo": "wp i18n make-mo ./resources/lang ./resources/lang"
   },
   "devDependencies": {
-    "@roots/bud": "6.21.0",
+    "@roots/bud": "6.20.0",
     "@roots/bud-eslint": "6.21.0",
     "@roots/bud-tailwindcss": "6.21.0",
     "@roots/bud-typescript": "6.21.0",


### PR DESCRIPTION
Attempt to resolve `cd` build failures subsequent to dependabot update https://github.com/codepuncher/asmm-bedrock/pull/738/files